### PR TITLE
Allow null css

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -3270,6 +3270,9 @@ Galleria.addTheme = function( theme ) {
         if ( !css ) {
             Galleria.raise('No theme CSS loaded');
         }
+    } else {
+        Galleria.theme = theme;
+        $doc.trigger( Galleria.THEMELOAD );
     }
     return theme;
 };


### PR DESCRIPTION
adds and else to the check for a theme's css that allows galleria to continue working.
