### PR TITLE
Flickr plugins improuvements - always display the best quality image

### DIFF
--- a/src/plugins/galleria.flickr.js
+++ b/src/plugins/galleria.flickr.js
@@ -174,7 +174,9 @@ F.prototype = {
 
             for ( var i=0; i<len; i++ ) {
                 var photo = photos[i],
-                img = photo.url_m;
+                
+				img = 'http://farm'+photo['farm']+'.static.flickr.com/'+photo['server']+
+                '/'+photo['id']+'_' + photo['secret'] + '_z.jpg';
 
                 switch(this.options.size) {
                     case 'small':
@@ -196,6 +198,8 @@ F.prototype = {
                     case 'original':
                     if( photo.url_o ) {
                         img = photo.url_o;
+                    } else 	if ( photo.url_l ) {
+                        img = photo.url_l;
                     }
                     break;
                 }


### PR DESCRIPTION
- changed default image size to a higher quality image size _z
- if the original is disabled for that flickr account, we will try to find the biggest size available instead 
