### PR TITLE
Add after/before DOM helper methods.

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -2752,6 +2752,40 @@ this.prependChild( 'info', 'myElement' );
     },
 
     /**
+        Fast helper for placing galleria elements after siblings that you added using addElement().
+
+        @param {string} siblingID The sibling element ID after which to place the element.
+        @param {string} elementID The element ID that should be placed after.
+
+        @example this.addElement( 'myElement' );
+                 this.after( 'info', 'myElement' );
+
+        @returns {Galleria}
+    */
+
+    after : function( siblingID, elementID ) {
+        this.$( siblingID ).after( this.get( elementID ) || elementID );
+        return this;
+    },
+
+    /**
+        Fast helper for placing galleria elements before siblings that you added using addElement().
+
+        @param {string} siblingID The sibling element ID before which to place the element.
+        @param {string} elementID The element ID that should be placed before.
+
+        @example this.addElement( 'myElement' );
+                 this.before( 'info', 'myElement' );
+
+        @returns {Galleria}
+    */
+
+    before : function( siblingID, elementID ) {
+        this.$( siblingID ).before( this.get( elementID ) || elementID );
+        return this;
+    },
+
+    /**
         Remove an element by blueprint
 
         @param {string} elemID The element to be removed.


### PR DESCRIPTION
Right now appendChild and prependChild give a lot of flexibility in building out the Galleria DOM, but there are some things that are very difficult to do (rearrange just parts of the DOM, or inserting an element between others). Therefore I propose adding two more DOM manipulation wrappers:
- Galleria.after( siblingID, elementID );
- Galleria.before( siblingID, elementID );

Technically, this can currently be accomplished directly in jQuery with `Galleria.$("myId").after( Galleria.get("myId") )`,  but that's a bit verbose. Since all of your other DOM tools are nicely wrapped behind Galleria's API, it'd be great to make this work the same.
