### PR TITLE
Enable configurable elements in setInfo()

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -1517,6 +1517,7 @@ Galleria.prototype = {
             imagePan: false,
             imagePanSmoothness: 12,
             imagePosition: '50%',
+            infoElements: ['title','description','author'],
             keepSource: false,
             lightboxFadeSpeed: 200,
             lightboxTransition_speed: 500,
@@ -3394,9 +3395,9 @@ this.prependChild( 'info', 'myElement' );
     },
 
     /**
-        Manually set captions
+        Manually set info
 
-        @param {number} index Optional data index to fectch and apply as caption,
+        @param {number} index Optional data index to fetch and apply info,
         if no index found it assumes the currently active index
 
         @returns Instance
@@ -3407,7 +3408,7 @@ this.prependChild( 'info', 'myElement' );
         var self = this,
             data = this.getData( index );
 
-        $.each( ['title','description','author'], function( i, type ) {
+        $.each( self._options.infoElements || [], function( i, type ) {
 
             var elem = self.$( 'info-' + type );
 


### PR DESCRIPTION
**This code is not ready to pull yet, I just wanted to start a pull request now to open a dialogue.**

Galleria.setInfo() is a really handy function, as it automates and abstracts updating any info elements in the gallery. However, right now it is limited to three hard-coded elements (title, description, author). This patch is the start of allowing those elements to be configurable.

Why might this be useful? An image is not limited to the three types of metadata listed, maybe you'd like to display the photographer name, or date the image was taken. By allowing the element list to be configurable, anything is possible.

This is easiest when using JSON data, as extra object properties will just be found, but also works fine with the dataConfig option (you'll have to manually move the values into the data array just like the main properties are done in Galleria.load).

There are a few ways to set this up, this branch demonstrates one by adding an "infoElements" config option. If you wanted this to be less accessible to users, another solution would be just to move the array of options to a property in the Galleria object so it could be manually updated. But as it is right now, it's impossible to add new info elements without completely overwriting the setInfo function.
