### PR TITLE
Changed a script include in the plugin demo files that was pointing to a missing galleria.js file, and not the one of the current version

### DIFF
--- a/src/plugins/flickr/flickr-demo.html
+++ b/src/plugins/flickr/flickr-demo.html
@@ -23,7 +23,7 @@
         <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.js"></script>
         
         <!-- load Galleria -->
-        <script src="../../galleria.js"></script>
+        <script src="../../galleria-1.2.5.js"></script>
         
         <!-- load flickr plugin -->
         <script src="galleria.flickr.js"></script>

--- a/src/plugins/history/history-demo.html
+++ b/src/plugins/history/history-demo.html
@@ -23,7 +23,7 @@
         <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.js"></script>
 
         <!-- load Galleria -->
-        <script src="../../galleria.js"></script>
+        <script src="../../galleria-1.2.5.js"></script>
 
         <!-- load the History plugin, no need for further scripting -->
         <script src="../../plugins/history/galleria.history.js"></script>

--- a/src/plugins/picasa/picasa-demo.html
+++ b/src/plugins/picasa/picasa-demo.html
@@ -23,7 +23,7 @@
         <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.js"></script>
         
         <!-- load Galleria -->
-        <script src="../../galleria.js"></script>
+        <script src="../../galleria-1.2.5.js"></script>
         
         <!-- load picasa plugin -->
         <script src="galleria.picasa.js"></script>


### PR DESCRIPTION
As per this issue: https://github.com/aino/galleria/issues/201

I simply pasted over the galleria.js script include with the correct version: galleria-1.2.5.js
