### PR TITLE
If an image is taking longer to download than usual, then the "could not extract height/width" error was being displayed. It couldn't be extracted because the image wasn't done downloading yet.

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -4788,19 +4788,17 @@ Galleria.Picture.prototype = {
                     // Delay the callback to "fix" the Adblock Bug
                     // http://code.google.com/p/adblockforchrome/issues/detail?id=3701
                     if ( ( !this.width || !this.height ) ) {
-                        window.setTimeout( (function( img ) {
-                            return function() {
-                                if ( img.width && img.height ) {
-                                    complete.call( img );
-                                } else {
-                                    Galleria.raise('Could not extract width/height from image: ' + img.src +
-                                        '. Traced measures: width:' + img.width + 'px, height: ' + img.height + 'px.');
-                                }
-                            };
-                        }( this )), 2);
-                    } else {
-                        complete.call( this );
-                    }
+						$(this).load(function(response, status){
+							if (status == 'error') {
+								Galleria.raise('Could not extract width/height from image: ' + img.src + 
+									'. Traced measures: width:' + img.width + 'px, height: ' + img.height + 'px.');
+							}
+							else complete.call(this);
+						});
+					}
+					else {
+						complete.call(this);
+					}
                 };
             }( this, callback, src ));
 


### PR DESCRIPTION
Fixed 'could not extract height/width of image' issue, if the image is taking longer than 2 seconds to download
