### PR TITLE
_scaleImage fix

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -3523,6 +3523,12 @@ this.prependChild( 'info', 'myElement' );
     _scaleImage : function( image, options ) {
 
         image = image || this._controls.getActive();
+        
+        // janpub (JH) fix:
+        // image might be unselected yet
+        // e.g. when external logics rescales the gallery on window resize events 
+        if(!image)
+          return;
 
         var self = this,
 


### PR DESCRIPTION
when gallery is externally rescalled e.g. on window resize event, image might still be null what fired an exception.

See:

_scaleImage : function( image, options ) {
        image = image || this._controls.getActive();

```
    // janpub (JH) fix:
    // image might be unselected yet
    // e.g. when external logics rescales the gallery on window resize events 
    if(!image)
      return;
```
