### PR TITLE
Fixes a NOT_FOUND_ERR in the DOM when initialising

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -2295,7 +2295,7 @@ Galleria.prototype = {
 
         Utils.hide( this.$( 'counter' ).append(
             this.get( 'current' ),
-            ' / ',
+            document.createTextNode(' / '),
             this.get( 'total' )
         ) );
 


### PR DESCRIPTION
To fix an error that occurs when the counter is added. See here for
more information:

(http://getsatisfaction.com/galleria/topics/dom_error_with_galleria_plugin)

Single change made was to alter the use of the append() function,
passing a text node rather than a string literal. New call is in-line
with the example from the jQuery documentation:

(http://api.jquery.com/append/#example-1)
