### PR TITLE
Thumbnails no longer being generated in latest beta

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -2753,7 +2753,7 @@ Galleria.prototype = {
                         }, onThumbLoad);
                     }
                 } else {
-                        thumb.load( src, onThumbLoad );
+                    thumb.load( src, onThumbLoad );
                 }
 
                 // preload all images here


### PR DESCRIPTION
With the latest beta, the thumbnails in my theme were no longer being generated (I was specifying the thumbnails for each image in a JSON array manually.) I looked at the source and it seems you just got your if statement tangled up a bit when checking if it's an image or video URL. This pull request should fix this issue.
