### PR TITLE
Fix error when idle & no 'active' image selected

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -1702,7 +1702,7 @@ Galleria = function() {
 
         hide : function() {
 
-            if ( !self._options.idleMode || self.getData().iframe ) {
+            if ( !self._options.idleMode || self.getIndex() === false || self.getData().iframe ) {
                 return;
             }
 


### PR DESCRIPTION
This would occur in the Folio theme since there is no active image on the stage
(just thumbnails). This is fixed by first checking to ensure there is an active
image before pulling the data.
