### PR TITLE
Fix issue with scaling using responsive: true

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -2566,7 +2566,7 @@ Galleria.prototype = {
 
             // set ratio if height is < 2
             if ( self._options.height < 2 ) {
-                self._ratio = self._options.height;
+                self._userRatio = self._ratio = self._options.height;
             }
 
             // the gallery is ready, let's just wait for the css
@@ -2913,8 +2913,8 @@ Galleria.prototype = {
         // allow setting a height ratio instead of exact value
         // useful when doing responsive galleries
 
-        if ( self._ratio ) {
-            num.height = num.width * self._ratio;
+        if ( self._userRatio ) {
+            num.height = num.width * self._userRatio;
         }
 
         return num;


### PR DESCRIPTION
Previously the gallery would maintain whatever aspect ratio it happened
to load with. This would cause a problem for galleries that occupy the
full browser width. Loading the gallery in a large browser window and
then scaling the window down resulted in a smaller gallery size
(occupying less of the available window) than what the user saw on a
reload at that smaller window size.

This patch fixes the issue by maintaining a separate variable to store
the user-provided aspect ratio (which should still be respected), as
opposed to the calculated ratio based on the stage dimensions at load
time.
