### PR TITLE
Picasa Plugin uses wrong API call for useralbum

### DIFF
--- a/src/plugins/picasa/galleria.picasa.js
+++ b/src/plugins/picasa/galleria.picasa.js
@@ -87,7 +87,7 @@ Galleria.Picasa.prototype = {
     */
 
     useralbum: function( username, album, callback ) {
-        return this._call( 'useralbum', 'user/' + username + '/album/' + album, callback );
+        return this._call( 'useralbum', 'user/' + username + '/albumid/' + album, callback );
     },
 
     /**


### PR DESCRIPTION
Included and set up Picasa plug-in (via Bower). Search was working fine. Switched to the following and got an error (Picasa request failed: album or user not found.):

```
Galleria.run('#galleria', {
  picasa: 'useralbum:116822487665710086731/5215542302391162465',
  picasaOptions: {
    sort: 'date-posted-asc'
  }
});
```

Looked in galleria.picasa.js and found:

```
useralbum: function( username, album, callback ) {
  return this._call( 'useralbum', 'user/' + username + '/album/' + album, callback );
}
```

According to [Google's API](https://developers.google.com/picasa-web/docs/2.0/developers_guide_protocol#ListAlbumPhotos) is should be:

```
useralbum: function( username, album, callback ) {
  return this._call( 'useralbum', 'user/' + username + '/albumid/' + album, callback );
}
```
