### PR TITLE
Possibility to swap source format.

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -4905,14 +4905,6 @@ this.prependChild( 'info', 'myElement' );
     },
 
     /**
-        Retrieve the format to display
-
-    */
-    getFormat : function(){
-        return this.getOptions('format');
-    },
-
-    /**
         Retrieve the option
 
         @param {string} key The option key to retrieve. If no key specified it will return all options in an object.


### PR DESCRIPTION
Added a 'format' option to swap picture format with a setFormat('image') function.

Default is set to 'image', ligthbox will still use 'big' but we can set any other format.

Here is an exemple to do a ['Youtube like'](http://perso.spope.fr/tmp/galleria/) expand
