### PR TITLE
Fix for vanishing thumbnails, when browser-zoom is active.

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -1170,6 +1170,11 @@ Galleria = window.Galleria = function() {
             $.each( self._thumbnails, function( i, thumb ) {
                 if ( thumb.ready ) {
                     w += thumb.outerWidth || $( thumb.container ).outerWidth( true );
+                    // Due to a bug in jquery, outerwidth() returns the floor of the actual outerwidth,
+                    // if the browser is zoom to a value other than 100%. height() returns the floating point value.
+                    var containerWidth = $( thumb.container).width();
+                    w += containerWidth - Math.floor(containerWidth);
+
                     hooks[ i+1 ] = w;
                     h = Math.max( h, thumb.outerHeight || $( thumb.container).outerHeight( true ) );
                 }


### PR DESCRIPTION
Hi, I discovered the problem that in some cases, the last thumbnail was invisible, when browser-zoom is active. The problem can be observed at [1]. When zooming to 90% the thumbnail disappears (e.g. in Chrome). The fix can be observed at [2]. When doing a lot of zooming, the last thumbnail may still disappear, but it is much more robust, than before the fix.

[1] ]http://www.knappi.org/galleria-error/themes/classic/classic-demo.html
[2] http://www.knappi.org/galleria-fixed/themes/classic/classic-demo.html

Due to a bug in jquery, outerwidth() returns the floor of the
actual outerwidth, if the browser is zoom to a value other than
100%. height() returns the floating point value.
This caused galleria to compute a wrong width for the 'thumbnails'
element. The container was not wide enough and the last thumbnail was
displayed in the next line, thus was effectively invisible.
