### PR TITLE
Config height value used prior to CSS value

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -2695,10 +2695,10 @@ Galleria.prototype = {
                 self._userRatio = self._ratio = self._options.height;
             }
 
-            // the gallery is ready, let's just wait for the css
+            // the gallery is ready, let's just wait for the css or use config by default
             var num = { width: 0, height: 0 };
             var testHeight = function() {
-                return self.$( 'stage' ).height();
+                return self._options.height || self.$( 'stage' ).height();
             };
 
             // check container and thumbnail height


### PR DESCRIPTION
The height set in config should be used instead of waiting for the CSS.

Sometimes the gallery may be hidden, then the height retrieved is 0, causing a fatal error.

To solve this issue, config value should be used if present.
