### PR TITLE
Destroy empty galleria

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -3963,7 +3963,7 @@ Galleria.prototype = {
         this.clearTimer();
         Utils.removeFromArray( _instances, this );
         Utils.removeFromArray( _galleries, this );
-        if ( Galleria._waiters.length ) {
+        if ( Galleria._waiters !== undefined && Galleria._waiters.length ) {
             $.each( Galleria._waiters, function( i, w ) {
                 if ( w ) window.clearTimeout( w );
             });


### PR DESCRIPTION
Check if _waiters exists when destroying a gallery, to prevent throwing
an undefined error, that will stop people from creating new galleries.
