### PR TITLE
Set width of galleria-thumbnails div to 100% conditionally for amount of...

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -1303,6 +1303,10 @@ Galleria = function() {
                 width: w,
                 height: h
             });
+            
+            if(self.$( 'thumbnails-container' ).width() >=  w) {
+              self.$( 'thumbnails' ).css('width', '100%');
+            }
 
             carousel.max = w;
             carousel.hooks = hooks;


### PR DESCRIPTION
Set the width of galleria-thumbnails div to 100% when sum of thumbnails combined widths exceeds or equals the width of galleria-thumbnails-container div.

Galleria currently sets a fixed pixel amount for the galleria-thumbnails div, and this causes the last thumbnail to wrap and become hidden in cases when the browser is zoomed out significantly. 

The proposed change will make for a more robust display of the thumbnails.
