### PR TITLE
Fix for issue #327 touch overriding mouse events.  Only allow touch on d...

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -5591,9 +5591,12 @@ $.extend( Galleria, {
     IPHONE:  /iphone/.test( NAV ),
     IPAD:    /ipad/.test( NAV ),
     ANDROID: /android/.test( NAV ),
-    TOUCH:   ('ontouchstart' in doc)
 
 });
+
+$.extend( Galleria, {
+  TOUCH: (Galleria.IPHONE || Galleria.IPAD || Galleria.ANDROID)
+} )
 
 // Galleria static methods
 


### PR DESCRIPTION
...evices we know are touch only and not touch and keyboard.

I am new to setting things up differently for touch or mouse interactions but this would seem to fix https://github.com/aino/galleria/issues/327 since we would only set Galleria to touch mode for devices we knew were touch only.  Not quite a dynamic as basing touch on if touch is available but it should avoid conquering mouse input
