### PR TITLE
Image over layer issue on webkit browsers with touch. (Issue #333)

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -6219,11 +6219,6 @@ Galleria.Picture.prototype = {
                             width: this.width
                         };
 
-                        // translate3d if needed
-                        if ( Galleria.HAS3D ) {
-                            this.style.MozTransform = this.style.webkitTransform = 'translate3d(0,0,0)';
-                        }
-
                         $container.append( this );
 
                         self.cache[ src ] = src; // will override old cache


### PR DESCRIPTION
This line seems to make the image appear over the image's layer under certain conditions in touch-enabled webkit browsers.

This is my first pull request and first time working with git so if there's anything I need to fix/change, please let me know!
