### PR TITLE
changing loader check to > 0

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -869,7 +869,7 @@ var doc    = window.document,
 
                     Utils.wait({
                         until: function() {
-                            return $loader.height() == 1;
+                            return $loader.height() > 0;
                         },
                         success: function() {
                             $loader.remove();


### PR DESCRIPTION
In some instances `$loader.height()` was greater than 0, but less than 1 (0.9544). This resulted in a false result that the `Theme CSS could not load after 20 sec`. Adjusting the conditional to check for `> 0` resolves the issue.