### PR TITLE
Lightbox fixes, carousel fix, themes cleanup.

### DIFF
--- a/src/galleria.js
+++ b/src/galleria.js
@@ -1368,7 +1368,10 @@ Galleria = function() {
             // one extra calculation
             carousel.width = self.$( 'thumbnails-list' ).width();
 
-            // todo: fix so the carousel moves to the left
+            // when carousel goes inactive, set default position (if it is not set already)
+            if ( w <= carousel.width && carousel.current ){
+                carousel.set(0);
+            }
         },
 
         bindControls: function() {

--- a/src/galleria.js
+++ b/src/galleria.js
@@ -2444,7 +2444,7 @@ Galleria = function() {
 
             lightbox.image.isIframe = ( data.iframe && !data.image );
 
-            $( lightbox.elems.box ).toggleClass( 'iframe', lightbox.image.isIframe );
+            $( lightbox.elems.box ).toggleClass( 'iframe', !!lightbox.image.isIframe );
 
             $( lightbox.image.container ).find( '.galleria-videoicon' ).remove();
 

--- a/src/galleria.js
+++ b/src/galleria.js
@@ -2408,9 +2408,6 @@ Galleria = function() {
                 lightbox.init();
             }
 
-            // trigger the event
-            self.trigger( Galleria.LIGHTBOX_OPEN );
-
             // temporarily attach some keys
             // save the old ones first in a cloned object
             if ( !lightbox.keymap ) {
@@ -2422,6 +2419,10 @@ Galleria = function() {
                     right: lightbox.showNext,
                     left: lightbox.showPrev
                 });
+
+                // trigger the event (can be here, as keymap is set each time lightbox opens)
+                self.trigger( Galleria.LIGHTBOX_OPEN );
+
             }
 
             $win.off('resize', lightbox.rescale );

--- a/src/galleria.js
+++ b/src/galleria.js
@@ -2248,7 +2248,7 @@ Galleria = function() {
             if ( IE > 7 ) {
                 exs = IE < 9 ? 'background:#000;filter:alpha(opacity=0);' : 'background:rgba(0,0,0,0);';
             } else {
-                exs = 'z-index:99999';
+                exs = 'z-index:99998';
             }
 
             cssMap.nextholder += exs;

--- a/src/themes/classic/galleria.classic.css
+++ b/src/themes/classic/galleria.classic.css
@@ -95,11 +95,11 @@
     cursor: pointer;
     display: none;
 }
-.galleria-theme-classic .notouch .galleria-info-close:hover{
+.galleria-theme-classic.notouch .galleria-info-close:hover{
     opacity:1;
     filter: alpha(opacity=100);
 }
-.galleria-theme-classic .touch .galleria-info-close:active{
+.galleria-theme-classic.touch .galleria-info-close:active{
     opacity:1;
     filter: alpha(opacity=100);
 }

--- a/src/themes/twelve/galleria.twelve.css
+++ b/src/themes/twelve/galleria.twelve.css
@@ -30,7 +30,7 @@
     background: #222 url(bar.png) repeat-x;
     z-index: 3;
 }
-.galleria-theme-twelve.light .galleria-bar{background:#fff;height:30px;;}
+.galleria-theme-twelve.light .galleria-bar{background:#fff;height:30px;}
 .galleria-theme-twelve .galleria-s1,
 .galleria-theme-twelve .galleria-s2,
 .galleria-theme-twelve .galleria-s3,


### PR DESCRIPTION
This fix 
- lightbox issues:

1) lightbox_open event (it triggered on on each image displayed in lightbox)
resolves #320 

2) lightbox close button (was not accesible)
resolves #318  resolves #405  

3) lightbox toggles "iframe" class (even if showing only images)
resolves #319 

- carousel
carousel remained moved on some situations (on resize, /f.ex. enter fullscreen/, when switched to no-carousel), so some images were hidden. this is fixed

- themes
some minor typos